### PR TITLE
Version 6.9.1.2602

### DIFF
--- a/ColorPicker.Setup/Setup.iss
+++ b/ColorPicker.Setup/Setup.iss
@@ -2,8 +2,8 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ColorPicker Max"
-#define MyAppVersion "6.9.0.2602"
-#define MyAppFullVersion "6.9.0.2602"
+#define MyAppVersion "6.9.1.2602"
+#define MyAppFullVersion "6.9.1.2602"
 #define MyAppPublisher "Léo Corporation"
 #define MyAppURL "https://leocorporation.dev/"
 #define MyAppExeName "ColorPicker.exe"

--- a/ColorPicker/Classes/Global.cs
+++ b/ColorPicker/Classes/Global.cs
@@ -95,7 +95,7 @@ public static class Global
 	internal static string SettingsPath => $@"{FileSys.AppDataPath}\Léo Corporation\ColorPicker Max\Settings.xml";
 	public static string LastVersionLink => "https://raw.githubusercontent.com/Leo-Corporation/LeoCorp-Docs/master/Liens/Update%20System/ColorPicker/5.0/Version.txt";
 
-	public static string Version => "6.9.0.2602";
+	public static string Version => "6.9.1.2602";
 
 	public static string HiSentence
 	{

--- a/ColorPicker/ColorPicker.csproj
+++ b/ColorPicker/ColorPicker.csproj
@@ -11,7 +11,7 @@
 	<Title>ColorPicker</Title>
 	<Description>Maximize your creativity.</Description>
 	<RepositoryUrl>https://github.com/Leo-Corporation/ColorPicker</RepositoryUrl>
-	<Version>6.9.0.2602</Version>
+	<Version>6.9.1.2602</Version>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<PackageIcon>logo.png</PackageIcon>
 	<ApplicationIcon>CPM.ico</ApplicationIcon>

--- a/ColorPicker/Properties/Resources.ja-JP.resx
+++ b/ColorPicker/Properties/Resources.ja-JP.resx
@@ -1,76 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-		Microsoft ResX Schema
-
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
+	Microsoft ResX Schema 
+	
+	Version 2.0
+	
+	The primary goals of this format is to allow a simple XML format 
+	that is mostly human readable. The generation and parsing of the 
+	various data types are done through the TypeConverter classes 
+	associated with the data types.
+	
+	Example:
+	
+	... ado.net/XML headers & schema ...
+	<resheader name="resmimetype">text/microsoft-resx</resheader>
+	<resheader name="version">2.0</resheader>
+	<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+	<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+	<data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+	<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+	<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+		<value>[base64 mime encoded serialized .NET Framework object]</value>
+	</data>
+	<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+		<value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+		<comment>This is a comment</comment>
+	</data>
+				
+	There are any number of "resheader" rows that contain simple 
+	name/value pairs.
+	
+	Each data row contains a name, and value. The row also contains a 
+	type or mimetype. Type corresponds to a .NET class that support 
+	text/value conversion through the TypeConverter architecture. 
+	Classes that don't support this are serialized and stored with the 
+	mimetype set.
+	
+	The mimetype is used for serialized objects, and tells the 
+	ResXResourceReader how to depersist the object. This is currently not 
+	extensible. For a given mimetype the value must be set accordingly:
+	
+	Note - application/x-microsoft.net.object.binary.base64 is the format 
+	that the ResXResourceWriter will generate, however the reader can 
+	read any of the formats listed below.
+	
+	mimetype: application/x-microsoft.net.object.binary.base64
+	value   : The object must be serialized with 
+			: System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
 			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
+	
+	mimetype: application/x-microsoft.net.object.soap.base64
+	value   : The object must be serialized with 
 			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
 			: and then encoded with base64 encoding.
 
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
+	mimetype: application/x-microsoft.net.object.bytearray.base64
+	value   : The object must be serialized into a byte array 
 			: using a System.ComponentModel.TypeConverter
 			: and then encoded with base64 encoding.
 	-->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -89,13 +109,13 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ColorPicker" xml:space="preserve">
 	<value>ColorPicker</value>
@@ -470,7 +490,7 @@
 	<value>Synethiaはこのデータを分析してユニークな体験を提供します</value>
   </data>
   <data name="SynethiaHome" xml:space="preserve">
-	<value>ホームダッシュボードは使用状況に基づいて操作を推奨します</value>
+	<value>ホームダッシュボードは使用状況に基づいて推奨操作を提案します</value>
   </data>
   <data name="SynethiaPrivacy" xml:space="preserve">
 	<value>お客様のデータは匿名でデバイスに保存されます。Léo Corporationにデータが送信されることはありません。</value>
@@ -578,7 +598,7 @@
     <value>10進数値をコピー</value>
   </data>
   <data name="AiPrompts" xml:space="preserve">
-    <value>Ocean Breeze,Crimson Sunset,Enchanted Forest,Electric Dreams,Desert Mirage,Midnight Serenade,Neon Galaxy,Golden Harvest,Lavender Mist,Tropical Paradise,Fire and Ice,Mystic Moonlight,Emerald Elegance,Cherry Blossom,Aurora Australis,Steel City Lights,Vintage Romance,Sapphire Dreams,Amber Afterglow,Velvet Touch,Dandelion Wishes,Urban Jungle,Rose Petal Whispers,Icy Tundra,Chocolate Delight,Harbor Reflections,Whispering Wind,Vibrant Spectrum,Pastel Reverie,Moonlit Meadow</value>
+    <value>海洋のそよ風,紅の夕焼け,魅惑の森,電光の夢,砂漠の蜃気楼,真夜中の小夜曲,ネオン銀河,黄金の収穫,ラベンダーの霧,熱帯楽園,炎と氷,神秘の月光,エメラルドの優雅さ,桜の花びら,オーロラ・オーストラリス,鋼鉄都市の灯り,ビンテージ・ロマンス,サファイアの夢,琥珀の残光,ベルベットの感触,タンポポの願い,都市のジャングル,薔薇のささやき,氷のツンドラ,チョコレートの喜び,港の反射,ささやく風,鮮やかなスペクトル,パステル幻想,月明かりの草原</value>
   </data>
   <data name="GetIdeas" xml:space="preserve">
     <value>アイデアの取得</value>
@@ -821,12 +841,12 @@
     <value>TailwindCSS</value>
   </data>
   <data name="LightDesc" xml:space="preserve">
-    <value>清潔で明るい</value>
+    <value>すっきり明るい</value>
   </data>
   <data name="DarkDesc" xml:space="preserve">
-    <value>暗い場所でも簡単</value>
+    <value>暗い場所でも見やすい</value>
   </data>
   <data name="DefaultThemeDesc" xml:space="preserve">
-    <value>好みに従います</value>
+    <value>システム設定に合わせる</value>
   </data>
 </root>


### PR DESCRIPTION
This pull request updates the application version to 6.9.1.2602 and makes several improvements to the Japanese resource file, including schema modernization and updated translations for better clarity and localization.

Version bump:

* Updated the application version to `6.9.1.2602` in `Setup.iss`, `Global.cs`, and `ColorPicker.csproj` to prepare for a new release. [[1]](diffhunk://#diff-4e636c188810a1b3730dbaa7889ed317fd7b3f7ded9bbf1ebc54758a7badbcefL5-R6) [[2]](diffhunk://#diff-de836a57d80836ce3a4386f634db2b18a3666c627a99fe5cbf8fc4c683405925L98-R98) [[3]](diffhunk://#diff-81fc7bae1c2b97a971ace066903172ed13d636918a4c8369fab506cf32666468L14-R14)

Japanese resource file improvements (`Resources.ja-JP.resx`):

* Modernized the RESX schema and metadata to version 2.0, updated .NET assembly references, and enhanced XML structure for better compatibility and maintainability. [[1]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L6-R6) [[2]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L17-R27) [[3]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L48-R49) [[4]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6R63-R93) [[5]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L92-R118)
* Improved Japanese translations for UI text, including clearer descriptions and more natural phrasing for several keys (e.g., `SynethiaHome`, `AiPrompts`, `LightDesc`, `DarkDesc`, `DefaultThemeDesc`). [[1]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L473-R493) [[2]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L581-R601) [[3]](diffhunk://#diff-97a12eafac5b21f693a004d27de69174ed075e77c3d6138c4308f523b22648d6L824-R850)